### PR TITLE
Updating kibana upload to use new url for old ELK

### DIFF
--- a/logsearch-jobs.yml
+++ b/logsearch-jobs.yml
@@ -169,6 +169,7 @@ instance_groups:
               - LogMessage
               - ContainerMetric
             system_domain: (( grab $CF_SYSTEM_DOMAIN ))
+            logs_hostname: logs-deprecated
             user: (( grab $CF_USERNAME ))
             password: (( grab $CF_PASSWORD ))
           kibana_objects:


### PR DESCRIPTION
## Changes proposed in this pull request:
- Kibana upload objects are not pointing to correct hostname


## security considerations
None