### PR TITLE
Adding 10GB_ephemeral_disk to all ls-plat vms

### DIFF
--- a/logsearch-platform-jobs.yml
+++ b/logsearch-platform-jobs.yml
@@ -50,6 +50,7 @@ instance_groups:
     vm_type: logsearch_es_master
     vm_extensions:
       - 10GB_root_disk
+      - 10GB_ephemeral_disk
     persistent_disk_type: logsearch_es_master
     stemcell: default
     azs: [z1, z2]
@@ -164,6 +165,7 @@ instance_groups:
     vm_type: logsearch_maintenance
     vm_extensions:
       - 10GB_root_disk
+      - 10GB_ephemeral_disk
     stemcell: default
     azs: [z1, z2]
     networks:
@@ -198,6 +200,7 @@ instance_groups:
     vm_type: logsearch_es_data
     vm_extensions:
       - 10GB_root_disk
+      - 10GB_ephemeral_disk
     persistent_disk_type: logsearch_es_platform_data
     stemcell: default
     azs: [z1, z2]
@@ -230,6 +233,7 @@ instance_groups:
     vm_type: logsearch_es_data
     vm_extensions:
       - 10GB_root_disk
+      - 10GB_ephemeral_disk
     persistent_disk_type: logsearch_es_platform_data_warm
     stemcell: default
     azs: [z1, z2]
@@ -368,6 +372,7 @@ instance_groups:
     vm_extensions:
       - platform-syslog-lb
       - 10GB_root_disk
+      - 10GB_ephemeral_disk
     persistent_disk_type: logsearch_ingestor
     stemcell: default
     azs: [z1, z2]
@@ -382,6 +387,7 @@ instance_groups:
     vm_extensions:
       - errand-profile
       - 10GB_root_disk
+      - 10GB_ephemeral_disk
     stemcell: default
     azs: [z1, z2]
     networks:


### PR DESCRIPTION
## Changes proposed in this pull request:
- Expand volume for ephemeral (used for /var/vcap/data) from default 5 to 10 GB

## security considerations
n/a
