### PR TITLE
update branch for logsearch-for-cloudfoundry repo from develop to main

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -630,7 +630,7 @@ resources:
     source:
       commit_verification_keys: ((cloud-gov-pgp-keys))
       uri: https://github.com/cloud-gov/logsearch-for-cloudfoundry
-      branch: develop
+      branch: main
   - name: logsearch-for-cloudfoundry-final-builds-dir-tarball
     type: s3-iam
     source:


### PR DESCRIPTION
## Changes proposed in this pull request:

- update branch for logsearch-for-cloudfoundry repo from develop to main

## security considerations

None, just updating pipeline to use different repo branch for source code
