### PR TITLE
Update default branches

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -608,7 +608,7 @@ resources:
     source:
       commit_verification_keys: ((cloud-gov-pgp-keys))
       uri: https://github.com/cloud-gov/logsearch-boshrelease
-      branch: develop
+      branch: main
   - name: logsearch-final-builds-dir-tarball
     type: s3-iam
     source:

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -630,7 +630,7 @@ resources:
     source:
       commit_verification_keys: ((cloud-gov-pgp-keys))
       uri: https://github.com/cloud-gov/logsearch-for-cloudfoundry
-      branch: develop
+      branch: main
   - name: logsearch-for-cloudfoundry-final-builds-dir-tarball
     type: s3-iam
     source:


### PR DESCRIPTION
## Changes proposed in this pull request:

- Update default branches for logsearch BOSH release repos

## security considerations

None - just updating the branches used to fetch source code for Logsearch BOSH releases
